### PR TITLE
Fix: Fixed the captcha input box not clearing on wrong captcha

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/pages/employee/Login/login.js
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/modules/core/src/pages/employee/Login/login.js
@@ -376,7 +376,7 @@ const Login = ({ config: propsConfig, t, isDisabled }) => {
                   <input
                     type="text"
                     placeholder="Enter Captcha"
-                    value={value || ""}
+                    value={captchaValue || ""}
                     autoComplete="off"
                     onChange={(e) => {
                       setCaptchaValue(e.target.value);


### PR DESCRIPTION
Fix: Fixed the captcha input box not clearing on wrong captcha. The captcha input box was displaying the old entered value even when the captcha image changed. Now it resets when captcha image reloads.